### PR TITLE
Feature: localImports option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,20 @@
+import { join } from "path"
 import type { Options, LocalsObject } from "pug"
 import type { Logger, Plugin } from "vite"
 import { compileFile } from "pug"
 import chalk from "chalk"
+
+export type PluginOptions = Options & {
+  /**
+   * Look for pug files in the directory
+   * of currently compiled index.html
+   * (locally)
+   * instead of project root.
+   * 
+   * Can accept a function to determine the option per-html-file.
+   */
+  localImports?: boolean | ((htmlfile: string) => boolean);
+};
 
 export function pugs(html: string, pugger: (filename: string) => string, logger?: Pick<Logger, "warn">) {
   return html.replace(/<pug.+?(file|src)="(.+?)".*?\/.*?>/gi, (_tag: string, attr: string, filename: string) => {
@@ -28,8 +41,26 @@ export default function (options?: Options, locals?: LocalsObject): Plugin {
     },
 
     transformIndexHtml: {
-      transform(html, { server }) {
-        return pugs(html, filename => compileFile(filename, options)(locals), server?.config.logger)
+      transform(html, { server, filename: htmlfile }) {
+        return pugs(html, filename => {
+          let filepath = filename;
+
+          const compile = () => compileFile(filepath, options)(locals);
+
+          if (options?.localImports) {
+            if (typeof options.localImports === 'function' && !options.localImports(htmlfile)) {
+              return compile();
+            }
+
+            // extract current directory from the html file path
+            const filedir = htmlfile.replace(/(.*)\/.*\.html/, '$1')
+
+            // apply current directory to the pug file imported from html
+            filepath = join(filedir, filename)
+          }
+
+          return compile();
+        }, server?.config.logger)
       },
     },
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,26 +40,25 @@ export default function (options?: Options, locals?: LocalsObject): Plugin {
       }
     },
 
+    
     transformIndexHtml: {
       transform(html, { server, filename: htmlfile }) {
         return pugs(html, filename => {
-          let filepath = filename;
-
-          const compile = () => compileFile(filepath, options)(locals);
-
-          if (options?.localImports) {
-            if (typeof options.localImports === 'function' && !options.localImports(htmlfile)) {
-              return compile();
-            }
-
+          const compile = (filepath: string) => compileFile(filepath, options)(locals);
+          if (
+            (typeof options?.localImports === 'function' && options.localImports(htmlfile))
+            || options?.localImports
+          ) {
             // extract current directory from the html file path
-            const filedir = htmlfile.replace(/(.*)\/.*\.html/, '$1')
+            const filedir = htmlfile.replace(/(.*)\/.*\.html$/, '$1')
 
             // apply current directory to the pug file imported from html
-            filepath = join(filedir, filename)
+            const filepath = join(filedir, filename);
+
+            return compile(filepath);
           }
 
-          return compile();
+          return compile(filename);
         }, server?.config.logger)
       },
     },


### PR DESCRIPTION
This allows the pug files imports (`<pug src=... />`) to be treated as any other import in vite - from the local directory of the html file.

Technically, solves #2

---

If the option is `true`, then this line:
https://github.com/SubZtep/vite-plugin-pug/blob/a73a104f20023ae8f9edc0e6aac7bf7c55aaf519/examples/multipage/nested/index.html#L2

would need to be changed to
```html
// Note the local import
<pug src="./index.pug"></pug>
```

---

Option is configurable per-file, and the default behaviour is backward-compatible.